### PR TITLE
Enable package validation to track public API compatibility

### DIFF
--- a/src/Pure.Primitives.Number.Operations/Pure.Primitives.Number.Operations.csproj
+++ b/src/Pure.Primitives.Number.Operations/Pure.Primitives.Number.Operations.csproj
@@ -6,6 +6,8 @@
     <Nullable>enable</Nullable>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <IsAotCompatible>true</IsAotCompatible>
+    <EnablePackageValidation>true</EnablePackageValidation>
+    <PackageValidationBaselineVersion>1.3.0</PackageValidationBaselineVersion>
   </PropertyGroup>
   <PropertyGroup>
     <PackageId>Pure.Primitives.Number.Operations</PackageId>


### PR DESCRIPTION
Closes #175

Add `EnablePackageValidation` and `PackageValidationBaselineVersion` to the project file so that breaking public API changes are detected during build/pack before publishing.