### PR TITLE
fix: return T.One for empty product instead of T.Zero

### DIFF
--- a/src/Pure.Primitives.Number.Operations/Product.cs
+++ b/src/Pure.Primitives.Number.Operations/Product.cs
@@ -14,7 +14,7 @@ public sealed record Product<T> : INumber<T>
 
     public T NumberValue =>
         !_values.Any()
-            ? T.Zero
+            ? T.One
             : _values
                 .Select(x => x.NumberValue)
                 .Aggregate((number1, number2) => number1 * number2);

--- a/src/Tests/Pure.Primitives.Number.Operations.Tests/ProductTests.cs
+++ b/src/Tests/Pure.Primitives.Number.Operations.Tests/ProductTests.cs
@@ -28,10 +28,10 @@ public sealed record ProductTests
     }
 
     [Fact]
-    public void TakeProductFromEmptyCollectionAsZero()
+    public void TakeProductFromEmptyCollectionAsOne()
     {
         INumber<int> product = new Product<int>([]);
-        Assert.Equal(0, product.NumberValue);
+        Assert.Equal(1, product.NumberValue);
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #209.

`Product<T>` now returns `T.One` for an empty collection (multiplicative identity). Updated the corresponding test from `TakeProductFromEmptyCollectionAsZero` to `TakeProductFromEmptyCollectionAsOne`.
