### PR TITLE
Update package validation baseline to 1.4.0

### DIFF
--- a/src/Pure.Primitives.Number.Operations/Pure.Primitives.Number.Operations.csproj
+++ b/src/Pure.Primitives.Number.Operations/Pure.Primitives.Number.Operations.csproj
@@ -7,7 +7,7 @@
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <IsAotCompatible>true</IsAotCompatible>
     <EnablePackageValidation>true</EnablePackageValidation>
-    <PackageValidationBaselineVersion>1.3.0</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>1.4.0</PackageValidationBaselineVersion>
   </PropertyGroup>
   <PropertyGroup>
     <PackageId>Pure.Primitives.Number.Operations</PackageId>


### PR DESCRIPTION
Bump `PackageValidationBaselineVersion` from `1.3.0` to `1.4.0` following the successful publish of 1.4.0.